### PR TITLE
Add publications

### DIFF
--- a/docs/source/publications.md
+++ b/docs/source/publications.md
@@ -1,0 +1,7 @@
+# Publications
+
+## Papers
+
+## Talks
+
+## Mentions in media


### PR DESCRIPTION
I added this to close #33. The page is empty, because well, we don't have any publications yet.

This can be merged though, as without `publications` added to the toctree, it won't be visible from the main page.