### PR TITLE
Removed restriction on sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=5.0,<6.0
+sphinx
 pydata-sphinx-theme
 myst-parser
 sphinx-design


### PR DESCRIPTION
The restriction is no longer necessary. Our current deployment workflows are compatible with the latest Sphinx version.