### PR TITLE
Add links to zulip

### DIFF
--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -8,7 +8,9 @@ The NIU is based at the [Sainsbury Wellcome Centre](https://www.sainsburywellcom
 
 
 ## Contact
-<a href="mailto:hello@neuroinformatics.dev ?subject=Neuroinformatics Unit">Email us</a>
+For help and support with individual tools, or just to get in touch, please use our [Zulip](https://neuroinformatics.zulipchat.com/).
+
+Alternatively, please <a href="mailto:adam.tyson@ucl.ac.uk ?subject=Neuroinformatics Unit">email Adam Tyson</a>.
 
 ## Location
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,6 +113,16 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
             # The type of image to be used (see below for details)
             "type": "fontawesome",
+        },
+        {
+            # Label for this link
+            "name": "Zulip (chat)",
+            # URL where the link will redirect
+            "url": "https://neuroinformatics.zulipchat.com/",  # required
+            # Icon class (if "type": "fontawesome"), or path to local image (if "type": "local")
+            "icon": "fa-solid fa-comments",
+            # The type of image to be used (see below for details)
+            "type": "fontawesome",
         }
    ],
    "logo": {


### PR DESCRIPTION
Closes #57 

This adds a link in the "about" section and a "chat" link in the top left (next to GitHub).