### PR TITLE
Conistent capitalisation for Python

### DIFF
--- a/docs/source/get-involved/languages_frameworks.md
+++ b/docs/source/get-involved/languages_frameworks.md
@@ -9,7 +9,7 @@ project structure. Part of using this cookiecutter is keeping it updated (e.g. P
 communicating those changes to all users.
 
 * Whenever possible, we will use `pyproject.toml` as the main configuration file for the project. Support for 
-`setup.cfg` and `setup.py` will be deprecated in future python versions. This will also be the default option for the SWC cookiecutter.
+`setup.cfg` and `setup.py` will be deprecated in future Python versions. This will also be the default option for the SWC cookiecutter.
 
 ### Virtual environments
 * We will use [conda](https://docs.conda.io/en/latest/) environments for all Python projects.

--- a/docs/source/projects.md
+++ b/docs/source/projects.md
@@ -81,7 +81,7 @@ It also allows these folders to be easily synchronised between computers.
 
 :::{grid-item-card} {fas}`code;sd-text-primary` Python Cookiecutter
 :link: https://github.com/neuroinformatics-unit/python-cookiecutter
-The Python Cookiecutter template allows quick and easy setup of new python projects.
+The Python Cookiecutter template allows quick and easy setup of new Python projects.
 Projects built using this template contain pre-set configurations for code quality checks, formatting,
 automated testing (pytest, both locally and through GitHub Actions), versioning and release on PyPI.
 :::


### PR DESCRIPTION

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We spell "Python" with capital "P" throughout the website except for two cases that we've missed.

Believe it or not, this was noticed by an eagle-eyed friend of mine, when I was showing them our website.

**What does this PR do?**

Converts those missed cases from "python" to "Python".
