### PR TITLE
Add Sofía as second organisation administrator

### DIFF
--- a/docs/source/get-involved/gsoc/index.md
+++ b/docs/source/get-involved/gsoc/index.md
@@ -91,16 +91,6 @@ Our working languages are Python and English ;) - but we also speak other langua
 Organisation administrator
 :::
 
-:::{grid-item-card} Alessandro Felder
-:img-top: ../../_static/alessandro_felder.png
-:link: https://github.com/alessandrofelder
-:text-align: center
-
-{fab}`github` [@alessandrofelder](https://github.com/alessandrofelder)
-
-Mentor
-:::
-
 :::{grid-item-card} Sofía Miñano
 :img-top: ../../_static/sofia_minano.png
 :link: https://github.com/sfmig
@@ -109,8 +99,18 @@ Mentor
 {fab}`github` [@sfmig](https://github.com/sfmig)
 
 
-Mentor
+Organisation administrator & mentor
 
+:::
+
+:::{grid-item-card} Alessandro Felder
+:img-top: ../../_static/alessandro_felder.png
+:link: https://github.com/alessandrofelder
+:text-align: center
+
+{fab}`github` [@alessandrofelder](https://github.com/alessandrofelder)
+
+Mentor
 :::
 
 :::{grid-item-card} Niko Sirmpilatze


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
The GSoC [rules](https://summerofcode.withgoogle.com/rules#:~:text=Each%20Organization%20must%20have%20at%20least%20two%20(2)%20Organization%20Administrators.) specify that:
 > Each Organization must have at least two (2) Organization Administrators.
 
**What does this PR do?**
After chatting with Adam we agreed I can be the second organisation administrator. This PR adds that role under my card name.

## References

In the [Mentor guide](https://google.github.io/gsocguides/mentor/#:~:text=Some%20org%20admins%20also%20mentor%20GSoC%20contributors%20during%20GSoC%2C%20and%20that%E2%80%99s%20perfectly%20fine%3B), it is also stated that there is no problem in someone holding both org admin and mentor roles.

## How has this PR been tested?

Docs build locally and in CI.

## Is this a breaking change?

\
## Does this PR require an update to the documentation?

\
## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
