### PR TITLE
Add publications and media section

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
 [codespell]
 skip = '.git'
 check-hidden = true
+ignore-words-list = portugues

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -57,10 +57,11 @@ to advance research in the two research centres and make new algorithms and tool
 about
 people
 projects
-collaborations
+publications
 blog/index
 roadmaps/index
 get-involved/index
 resources
+collaborations
 open-software-week/index
 ```

--- a/docs/source/publications.md
+++ b/docs/source/publications.md
@@ -1,7 +1,77 @@
-# Publications
+# Publications & Media
 
-## Papers
+## Papers and preprints
+
+### Neuroinformatics Unit publications
+::::{grid} 1 1 1 1
+:gutter: 3
+
+:::{grid-item-card}
+:link: https://doi.org/10.48550/arXiv.2505.16882
+Duporge, I., Minano, S., **Sirmpilatze, N., Tatarnikov, I.**, Wolf, S., **Tyson, A. L.**, Rubenstein, D. (2025) "Tracking the Flight: Exploring a Computational Framework for Analyzing Escape Responses in Plains Zebra (Equus quagga)" *arXiv* 2505.16882, doi.org/10.48550/arXiv.2505.16882
+:::
+
+:::{grid-item-card}
+:link: https://doi.org/10.1101/2025.03.04.641293
+**Sirmpilatze, N., Felder, A.**, Abdulazhanova, D., Schwigon, L., Haase, K., Musielak, I., Margrie, T. W., Mouritsen, H., Heyers, D., **Tyson, A. L.**, Weiler, S. (2025) "Mapping the magnetoreceptive brain: A 3D digital atlas of the migratory bird Eurasian blackcap (Sylvia atricapilla)" *bioRxiv* 2025.03.04.641293, doi.org/10.1101/2025.03.04.641293
+:::
+
+:::{grid-item-card}
+:link: https://doi.org/10.1101/2024.03.06.583699
+Domine, C. C. J., Carrasco-Davis, R., Hollingsworth L., **Sirmpilatze, N., Tyson, A. L.**, Jarvis, D., Barry, C., Saxe, A. M. (2024) “NeuralPlayground: A Standardised Environment for Evaluating Models of Hippocampus and Entorhinal Cortex” *bioRxiv*, doi.org/10.1101/2024.03.06.583699
+:::
+::::
+
+### Publications relating to Neuroinformatics Unit software
+
+::::{grid} 1 1 1 1
+:gutter: 3
+
+:::{grid-item-card}
+:link: https://doi.org/10.1038/s41598-021-04676-9
+**Tyson, A. L.**, Vélez-Fort, M., Rousseau, C. V., Cossell, L., Tsitoura, C., Lenzi, S. C., Obenhaus, H. A., Claudi, F., Branco, T., Margrie, T. W. (2022) "Accurate determination of marker location within whole-brain microscopy images" *Scientific Reports*, doi.org/10.1038/s41598-021-04676-9
+:::
+
+:::{grid-item-card}
+:link: https://doi.org/10.1371/journal.pcbi.1009074
+**Tyson, A. L.**, Rousseau, C. V., Niedworok, C. J., Keshavarzi, S., Tsitoura, C., Cossell, L., Strom, M., Margrie, T. W. (2021) "A deep learning algorithm for 3D cell detection in whole mouse brain image datasets" *PLOS Computational Biology* 17(5): e1009074, doi.org/10.1371/journal.pcbi.1009074
+:::
+
+:::{grid-item-card}
+:link: https://doi.org/10.7554/eLife.65751
+Claudi, F., **Tyson, A. L.**, Petrucco, L., Margrie, T.W., Portugues, R., Branco, T. (2021) "Visualizing anatomically registered data with Brainrender" *eLife* 2021;10:e65751 doi.org/10.7554/eLife.65751
+:::
+
+:::{grid-item-card}
+:link: https://doi.org/10.21105/joss.02668
+Claudi, F., Petrucco, L., **Tyson, A. L.**, Branco, T., Margrie, T. W., Portugues, R. (2020) "BrainGlobe Atlas API: a common interface for neuroanatomical atlases" *Journal of Open Source Software* 5(54), 2668 doi.org/10.21105/joss.02668
+:::
+
+::::
 
 ## Talks
 
-## Mentions in media
+::::{grid} 1 1 1 1
+:gutter: 3
+
+:::{grid-item-card} movement: A Python toolbox for analysing animal body movements
+:link: https://youtu.be/GXBQsqqZZTg?si=0bt5Q_lGY8GXw6dx
+Niko Sirmpilatze, ABIDE seminar, Febuary 2025
+:::
+
+:::{grid-item-card} Aligning spikes to histology with BrainGlobe
+:link: https://youtu.be/ck-2vNR7qwo?si=awOA9sEw7xRl9-Nf
+Alessandro Felder, UCL Neuropixels course, October 2024
+:::
+
+:::{grid-item-card} Aligning spikes to histology with BrainGlobe
+:link: https://www.youtube.com/watch?v=JQ-vYx42L6s
+Adam Tyson, UCL Neuropixels course, October 2023
+:::
+
+:::{grid-item-card} BrainGlobe: a Python ecosystem for computational (neuro)anatomy
+:link: https://www.youtube.com/watch?v=Ndsssf_gHns
+Adam Tyson, World Wide Series | Open Neuroscience, May 2021
+:::
+
+::::

--- a/docs/source/publications.md
+++ b/docs/source/publications.md
@@ -56,7 +56,7 @@ Claudi, F., Petrucco, L., **Tyson, A. L.**, Branco, T., Margrie, T. W., Portugue
 
 :::{grid-item-card} movement: A Python toolbox for analysing animal body movements
 :link: https://youtu.be/GXBQsqqZZTg?si=0bt5Q_lGY8GXw6dx
-Niko Sirmpilatze, ABIDE seminar, Febuary 2025
+Niko Sirmpilatze, ABIDE seminar, February 2025
 :::
 
 :::{grid-item-card} Aligning spikes to histology with BrainGlobe

--- a/docs/source/publications.md
+++ b/docs/source/publications.md
@@ -8,7 +8,7 @@
 
 :::{grid-item-card}
 :link: https://doi.org/10.48550/arXiv.2505.16882
-Duporge, I., Minano, S., **Sirmpilatze, N., Tatarnikov, I.**, Wolf, S., **Tyson, A. L.**, Rubenstein, D. (2025) "Tracking the Flight: Exploring a Computational Framework for Analyzing Escape Responses in Plains Zebra (Equus quagga)" *arXiv* 2505.16882, doi.org/10.48550/arXiv.2505.16882
+Duporge, I., **Minano, S., Sirmpilatze, N., Tatarnikov, I.**, Wolf, S., **Tyson, A. L.**, Rubenstein, D. (2025) "Tracking the Flight: Exploring a Computational Framework for Analyzing Escape Responses in Plains Zebra (Equus quagga)" *arXiv* 2505.16882, doi.org/10.48550/arXiv.2505.16882
 :::
 
 :::{grid-item-card}


### PR DESCRIPTION
This PR adds a new "Publications and media" page for us to list:
- Journal publications/preprints
- Talks
- Other stuff, like blogposts elsewhere

It also "downgrades" the collaborations page and puts it under the "More" heading. I figured publications was more important.

Some questions (all of these could be saved for later PRs)
- Do we want to format this better in any way? I went with something simple so it's easy to update
- Do we all agree adding the BrainGlobe publications here? They aren't really NIU publications, but I figured some people might look here to find them. 
- Do we have any more recorded talks we could add?
- Do we have anything else we could add, e.g. external blogs?


Closes https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/issues/77