### PR TITLE
Make clear OSW registration is closed

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,6 @@ html_favicon = "_static/logo_light.png"
 
 # Cutomize the theme
 html_theme_options = {
-    "announcement": "The Neuroinformatics Unit is hosting its inaugural Open Software Week during the week of 11th-15th August 2025! <a href='https://neuroinformatics.dev/open-software-week/index.html'>Find out more</a>!",
     "icon_links": [
         {
             # Label for this link

--- a/docs/source/open-software-week/animals-in-motion.md
+++ b/docs/source/open-software-week/animals-in-motion.md
@@ -64,7 +64,3 @@ It's a great chance to get feedback on your data and learn from others.
 If you don't have your own data, we will provide example datasets for you to work with.
 
 We expect that participant-led ideas emerging from this track may inspire collaborative projects during the __Hackday__ on Friday.
-
-### Apply now!
-
-Fill in [this Google form](https://forms.gle/2UAAzikhSgYArZpX7) to apply. We unfortunately have limited space to accommodate participants. To maximise our impact, we aim to select participants that would benefit the most from the event, and that can bring the experience back to a diverse set of fields. Please be specific in your application and tailor it to the main track(s) that you are planning to attend. There is funding for travel and accommodation available. Applicants will be informed of the outcome by early July.

--- a/docs/source/open-software-week/big-imaging-data.md
+++ b/docs/source/open-software-week/big-imaging-data.md
@@ -63,9 +63,6 @@ We expect that participant-led ideas emerging from this track may inspire collab
 
 If you're interested analysis tools for whole-organ imaging (particularly brains), you might also benefit from attending the preceding two-day [BrainGlobe main track](brainglobe.md).
 
-### Apply now!
-
-Fill in [this Google form](https://forms.gle/2UAAzikhSgYArZpX7) to apply. We unfortunately have limited space to accommodate participants. To maximise our impact, we aim to select participants that would benefit the most from the event, and that can bring the experience back to a diverse set of fields. Please be specific in your application and tailor it to the main track(s) that you are planning to attend. There is funding for travel and accommodation available. Applicants will be informed of the outcome by early July.
 
 [^1]: community initiatives around e.g. the [Software Sustainability Institute](https://www.software.ac.uk/), the [Society for Research Software Engineering](https://society-rse.org/about/history/), and The Hidden REF.
 [^2]: For example [BioImagingUK](https://www.rms.org.uk/community/networks-affiliates/bioimaginguk-network.html), [Euro-BioImaging](https://www.eurobioimaging.eu/), [Global Bioimaging](https://globalbioimaging.org/)

--- a/docs/source/open-software-week/brainglobe.md
+++ b/docs/source/open-software-week/brainglobe.md
@@ -63,7 +63,3 @@ It's a great chance to get feedback on your data and learn from others.
 If you don't have your own data, we will provide example datasets for you to work with.
 
 We expect that participant-led ideas emerging from this track may inspire collaborative projects during the __Hackday__ on Friday.
-
-### Apply now!
-
-Fill in [this Google form](https://forms.gle/2UAAzikhSgYArZpX7) to apply. We unfortunately have limited space to accommodate participants. To maximise our impact, we aim to select participants that would benefit the most from the event, and that can bring the experience back to a diverse set of fields. Please be specific in your application and tailor it to the main track(s) that you are planning to attend. There is funding for travel and accommodation available. Applicants will be informed of the outcome by early July.

--- a/docs/source/open-software-week/index.md
+++ b/docs/source/open-software-week/index.md
@@ -3,13 +3,13 @@
 We are excited to announce our inaugural **NIU Open Software Week**, taking
 place in **August 2025** in **London, UK**. This event will bring together researchers, developers, and users of open-source software for some hands-on training, community-building and hacking.
 
-:::{admonition} Applications are open. Apply for your spot now by filling in [this Google form](https://forms.gle/2UAAzikhSgYArZpX7)!
+:::{admonition} Application Period Closed. We will notify applicants of acceptance as soon as possible.
 :class: info
 
 **August 11-15 2025**, [Sainsbury Wellcome Centre](https://maps.app.goo.gl/CzWFFjXJZwX87aMj6)
 
-- **April 16th 2025**: Applications open
-- **June 6th 2025**: Applications close
+- ~~**April 16th 2025**: Applications open~~
+- ~~**June 6th 2025**: Applications close~~
 - **End of June/Early July 2025**: Applicants are notified of acceptance
 :::
 


### PR DESCRIPTION
Remove announcement banner, links to google form, and make clear the registrations is closed now.