### PR TITLE
Remove global 1rem auto margin (css)

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -37,7 +37,6 @@ html[data-theme=dark] .bd-main img {
 .bd-article img, 
 .bd-content img {
   display: block;
-  /* margin: 1rem auto; */
   max-width: 100%;
   height: auto;
 }

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -37,7 +37,7 @@ html[data-theme=dark] .bd-main img {
 .bd-article img, 
 .bd-content img {
   display: block;
-  margin: 1rem auto;
+  /* margin: 1rem auto; */
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Images in the website have now an annoying margin at the top and bottom.

**What does this PR do?**
Identifies the css line that caused the issue and eliminates it. 

## References
Caused by css change in #163 

## How has this PR been tested?
Built locally to assess css changes

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
