### PR TITLE
Use raw html link for Dropbox

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,6 @@ templates_path = ["_templates"]
 # https://github.com/neuroinformatics-unit/actions/pull/24#issue-1978966182
 linkcheck_anchors_ignore_for_url = ["https://neuroinformatics.zulipchat.com/"]
 linkcheck_ignore = [
-    "https://www.dropbox.com",
     "https://opensource.org",
     "https://www.incf.org/recommendations-gsoc-contributors",
     "https://www.incf.org/sites/default/files/files/INCF_GSoC_2022_Application_template.pdf",

--- a/docs/source/open-software-week/animals-in-motion.md
+++ b/docs/source/open-software-week/animals-in-motion.md
@@ -116,7 +116,10 @@ It's a great chance to get feedback on your data and learn from others.
 :class: note
 
 We also provide some example datasets for you to use during the workshop.
-Please download these from [Dropbox](https://www.dropbox.com/scl/fo/81ug5hoy9msc7v7bteqa0/AH32RLdbZqWZJstIeR4YHZY?rlkey=blgagtaizw8aac5areja6h7q1&st=xni448zl&dl=0) before the workshop starts (they are a few GB in size).
+Please download these from
+<a href="https://www.dropbox.com/scl/fo/81ug5hoy9msc7v7bteqa0/AH32RLdbZqWZJstIeR4YHZY?rlkey=blgagtaizw8aac5areja6h7q1&st=xni448zl&dl=0">
+Dropbox </a>
+before the workshop starts (they are a few GB in size).
 
 :::
 

--- a/docs/source/open-software-week/animals-in-motion.md
+++ b/docs/source/open-software-week/animals-in-motion.md
@@ -116,7 +116,7 @@ It's a great chance to get feedback on your data and learn from others.
 :class: note
 
 We also provide some example datasets for you to use during the workshop.
-Please download these from [Dropbox](https://www.dropbox.com/scl/fo/81ug5hoy9msc7v7bteqa0/AH32RLdbZqWZJstIeR4YHZY?rlkey=blgagtaizw8aac5areja6h7q1&st=w1zueyi9&dl=0) before the workshop starts (they are a few GB in size).
+Please download these from [Dropbox](https://www.dropbox.com/scl/fo/81ug5hoy9msc7v7bteqa0/AH32RLdbZqWZJstIeR4YHZY?rlkey=blgagtaizw8aac5areja6h7q1&st=xni448zl&dl=0) before the workshop starts (they are a few GB in size).
 
 :::
 


### PR DESCRIPTION
Sphinx was rendering `&` as `&amp` in the dropbox link, resulting in a broken link.

As a workaround, I've used a raw html link which works, I've tested it with a local build.
I was also able to no longer ignore dropbox in linkcheck, which should catch such errors in future.