### PR TITLE
Add gsoc 2025 datashuttle redirect.

### DIFF
--- a/docs/source/gsoc-2025-datashuttle.md
+++ b/docs/source/gsoc-2025-datashuttle.md
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="refresh" content="0; url=/blog/datashuttle_gsoc2025.html">
+</head>
+<body>
+    <p>If you are not redirected, <a href="/blog/datashuttle_gsoc2025.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a redirect link for the datashuttle 2025 GSoC blog.

We explored adding redirects with `sphinx_reredirects` , redirecting from the original page in case of future refactor. However, this (having a single `gsoc-2025-datashuttle.md` in the source) is cleaner as if you move a page multiple times you only have to change the link on that page, avoiding a chain of redirects in the `conf.py`. It is also cleaner to have it in the `/source/` rather than maintaining a possibly vestigial `/blog` folder (which is where the original page is).