### PR TITLE
Add artifact-ci action to allow viewing docs in the PR

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -27,7 +27,9 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+        with:
+          use-artifactci: lazy
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
This PR adds `artifact-ci` to the docs build (e.g. as in [movement](https://github.com/neuroinformatics-unit/movement/pull/631/files)) so that the docs changed in a PR can be viewed online without having to build locally.
