### PR TITLE
Fix SI quality metrics link.

### DIFF
--- a/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
+++ b/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
@@ -55,7 +55,7 @@ in [SpikeInterface](https://github.com/SpikeInterface/spikeinterface). We will a
 
 In this session, we will cover how to assess the quality of the sorting outputs:
 * Introduction to the different types of quality metrics
-* Computing [quality metrics in SpikeInterface](https://spikeinterface.readthedocs.io/en/latest/modules/qualitymetrics.html)
+* Computing [quality metrics in SpikeInterface](https://spikeinterface.readthedocs.io/en/stable/modules/qualitymetrics.html)
 and [Bombcell](https://github.com/Julie-Fabre/bombcell)
 * Assessing the sorter output in the [SpikeInterface GUI](https://github.com/SpikeInterface/spikeinterface-gui)
 * Creating and applying models which perform automated curation with [UnitRefine](https://www.biorxiv.org/content/10.1101/2025.03.30.645770v1)


### PR DESCRIPTION
This PR fixes the broken link:

```
https://spikeinterface.readthedocs.io/en/latest/modules/qualitymetrics.html
```

replacing it with

```
https://spikeinterface.readthedocs.io/en/stable/modules/qualitymetrics.html
```

It should have originally been this, as this links to the latest release (not main branch) version of the docs. I think this means the link will break in future when SI do their next release, as I guess the location of that page has changed on main. But we can update when required, it should be pointing to stable.