### PR TITLE
Add more ephys instructors.

### DIFF
--- a/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
+++ b/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
@@ -80,8 +80,14 @@ The final two days are dedicated to collaboration. We will join forces with part
 * **Presentation:** teams will have the opportunity to share their progress and outcomes on the final afternoon.
 
 ## Confirmed Instructors
+
 * [Joseph Ziminski](https://github.com/JoeZiminski)
-* [Chris Halcrow](https://github.com/chrishalcrow)
+* [Chris Halcrow](https://github.com/chrishalcrow) 
+* [Wolf de Wulf](https://github.com/wulfdewolf) 
+* [Alessio Buccino](https://github.com/alejoe91)
+* [Samuel Garcia](https://github.com/samuelgarcia) 
+* [Olivier Winter](https://github.com/oliche) 
+
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR adds more instructors to the ephys page, I still need to contact UnitMatch team which I will do now.

Initially I had like Name (affiliation) see below but I wasn't sure if this was confusing and it looked like it could be what they are teaching. Not sure if its necessary or beneficial to have something like this.

<img width="564" height="283" alt="image" src="https://github.com/user-attachments/assets/1136ef06-cd45-435e-ab9b-456d9b35ce67" />

