### PR TITLE
Fixed sponsor logo sizing inconsistency on About page - #192

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -42,7 +42,7 @@ html[data-theme=dark] .bd-main img {
 }
 
 .bd-article .sponsor {
-  height: 50px;
+  height: 100px;
   padding-top: 5px;
   padding-right: 5px;
   padding-bottom: 5px;


### PR DESCRIPTION
## Related Tickets & Documents

Fixes: #192 

---

## Description

Fixes inconsistent sizing of sponsor logos on the About page by enforcing a consistent height across light and dark modes.

---

## Current Behaviour

* In light mode, sponsor logos appear too large
* In dark mode, the CZI logo appears larger than expected
* Default theme styles override sponsor-specific CSS in some contexts

---

## Expected Output (Implemented)

* Sponsor logos in the main content area (`.bd-article .sponsor`) are fixed at **50px height**
* Logo sizing is now consistent with footer sponsor logos
* Increased CSS specificity prevents theme overrides

---

## Type of Change

* [x] Bug fix
* [x] UI improvement

---

## Testing

* Built documentation locally using `sphinx-build`
* Verified correct logo sizing in both light and dark modes

---

## Environment and Dependencies

* New Dependencies: None
* Configuration Changes: None

---

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have run the build command to ensure there are no build errors
* [x] My changes have been tested across relevant themes/modes

Before : 
<img width="635" height="396" alt="dark" src="https://github.com/user-attachments/assets/6c0c673d-73aa-459d-b9ba-2903dfa402cb" />
<img width="736" height="803" alt="light" src="https://github.com/user-attachments/assets/1fa0ee6d-490d-472a-8f32-461005e6f8be" />

After : 
<img width="1904" height="912" alt="Screenshot 2026-01-02 154816" src="https://github.com/user-attachments/assets/b2158f06-d695-4f5d-aec9-9aa3312f4dd9" />
<img width="1878" height="909" alt="Screenshot 2026-01-02 154836" src="https://github.com/user-attachments/assets/d0170f78-46ee-4143-a7a6-76f762f09a0c" />

Video Testing : 


https://github.com/user-attachments/assets/14bddf93-a8f2-4163-ba1b-759ed4f50c20

