### PR TITLE
Add schedule for Animals in Motion 2026

### DIFF
--- a/docs/source/open-software-summer-school/2026/animals-in-motion.md
+++ b/docs/source/open-software-summer-school/2026/animals-in-motion.md
@@ -35,7 +35,7 @@ While icons of mice are used for illustration, the course content should be appl
 | Monday<br>morning | Introduction and key concepts | A big-picture overview of analysis workflows and tools for animal behaviour, followed by a primer on deep learning for computer vision. |
 | Monday<br>afternoon | Symposium | Participants present their work and network with other participants. |
 | Tuesday<br>morning | Pose estimation | A practical tutorial on [SLEAP](https://sleap.ai/)—a popular software library for animal pose estimation and tracking. You will learn how to annotate video frames, train deep learning models, and generate motion tracks from new videos. |
-| Tuesday<br>afternoon | Motion quantification | A hands-on tutorial on [movement](https://movement.neuroinformatics.dev)—a Python package for cleaning, visualising, and analysing motion tracks produced by [SLEAP](https://sleap.ai/), [DeepLabCut](https://deeplabcut.org/) and similar tools. |
+| Tuesday<br>afternoon | Motion quantification | A practical introduction to [movement](https://movement.neuroinformatics.dev)—a Python package for cleaning, visualising, and analysing motion tracks produced by [SLEAP](https://sleap.ai/), [DeepLabCut](https://deeplabcut.org/) and similar tools. |
 | Wednesday<br>morning | Case studies | A hands-on tutorial on applying markerless motion tracking and quantification to real-world case studies through coding exercises. |
 | Wednesday<br>afternoon | Behaviour segmentation | A primer on decomposing continuous motion into discrete actions, followed by a practical tutorial on a supervised behaviour segmentation tool. |
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Timings are not given for the listed topics.

**What does this PR do?**

I organised the topics into a schedule (split by half days) and displayed them in a markdown table. The final display format will be decided on together with the other track leads, see discussion under #220.

<img width="946" height="574" alt="image" src="https://github.com/user-attachments/assets/d66a01c3-270d-47ea-9e72-7b02eaba3c63" />

@sfmig and @lochhh let me know if the time allocated to each topic (and their ordering) seems reasonable to you.

## References

#220 (adding a schedule for "Large Array Data".

## How has this PR been tested?

Local documentation build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
