### PR TITLE
Pin sphinx < 9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<9
 pydata-sphinx-theme
 myst-parser
 sphinx-design


### PR DESCRIPTION
Temporarily until ablog catches up (next ablog release) - so we can merge the OSSS schedules

(the bugfix has just been merge on the ablog side https://github.com/sunpy/ablog/issues/313)
