### PR TITLE
Fix navbar alignment by adding navbar_align configuration to PyData Sphinx Theme

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -72,3 +72,9 @@ html[data-theme=dark] .bd-main img {
   flex-wrap: wrap;
   justify-content: space-between;
 }
+
+/* Align navigation links to the left and add padding between logo and nav */
+.bd-header .navbar-header-items__start {
+  margin-right: 0 !important;
+  padding-right: 1.5rem;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,8 +125,9 @@ html_css_files = [
 
 html_favicon = "_static/logo_light.png"
 
-# Cutomize the theme
+# Customize the theme
 html_theme_options = {
+"navbar_align": "left",
     "icon_links": [
         {
             # Label for this link


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The navigation links in the documentation were centred by default, . This PR fixes the alignment issue by configuring the navbar to be left-aligned.

**What does this PR do?**

This PR adds the `navbar_align: "left"` configuration option to the PyData Sphinx Theme settings in `docs/source/conf.py`. This ensures that navigation links are left-aligned instead of centered, providing better visual consistency with the overall documentation layout.

Additionally, this PR fixes a minor typo in the comment (`Cutomize` → `Customize`).

## References

Fixes : neuroinformatics-unit/python-cookiecutter#168  

## How has this PR been tested?

- Built the documentation locally using Sphinx
- Verified that the navigation links now appear left-aligned in the rendered HTML output
- Confirmed that no other functionality or styling has been affected

## Is this a breaking change?

No, this is not a breaking change. This is a purely visual/styling update that does not affect any existing functionality or APIs.

## Does this PR require an update to the documentation?

No documentation updates are required. This change only affects the visual presentation of the existing documentation, not its content or structure.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (N/A for configuration changes)
- [ ] The documentation has been updated to reflect any changes (N/A - visual change only)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
Before:
<img width="1916" height="860" alt="image" src="https://github.com/user-attachments/assets/59055718-01b5-48fb-af8f-710904d068d9" />
<img width="1919" height="863" alt="image" src="https://github.com/user-attachments/assets/192a5090-24ad-4daa-bda5-32c52fc4b972" />

After : 
<img width="1904" height="914" alt="image" src="https://github.com/user-attachments/assets/2468f1ee-93dd-43c5-88ec-5cb1de2bcbbc" />
<img width="1919" height="920" alt="image" src="https://github.com/user-attachments/assets/0aaf7941-8b58-4d8d-a5d0-ca48aa1168d0" />

