### PR TITLE
unpin sphinx and pin ablog

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
-sphinx<9
+sphinx
 pydata-sphinx-theme
 myst-parser
 sphinx-design
 numpydoc
 nbsphinx
 linkify-it-py
-ablog
+ablog>=0.11.13
 sphinx-sitemap
 sphinx-icon
 sphinx-reredirects


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: dependencies

**Why is this PR needed?**

Closes #226.

`ablog` is now compatible with Sphinx v9, as of [ablog v0.11.13](https://github.com/sunpy/ablog/releases/tag/v0.11.13).

**What does this PR do?**

Unpins sphinx and instead constrains `ablog` to versions equal or above `v0.11.13`.

## References

https://github.com/sunpy/ablog/pull/313
https://github.com/sunpy/ablog/pull/314

## How has this PR been tested?

Local docs build in a fresh environment.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
