### PR TITLE
Add GSoC 2026 blog post on single-channel cellfinder support

### DIFF
--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -47,7 +47,7 @@ In napari, you leave the background image unselected.
 
 I used the same ResNet-50 architecture and training dataset as the standard two-channel model, but dropped the background channel during training to create our first single-channel model. I then uploaded it to the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), marking the start of our transition to hosting models there. It downloads automatically on first use, just like the existing models.
 
-I then compared our results against the two-channel model to understand the trade-offs it would have. Early tests on data from a different microscope produced more false positives: objects incorrectly identified as cells. I tested both models on the same set of 10,756 image cubes, containing 5,066 cells and 5,690 non-cell objects, and varied the proportion of cells in the training data to see how it affected their performance.
+I then compared our results against the two-channel model to understand the trade-offs it would have. Early tests on data from a different microscope produced more false positives: objects incorrectly identified as cells. I tested both models on the same set of 10,756 image cubes, containing 5,066 cells and 5,690 non-cell objects, and varied the proportion of cells in the training data to see how it affected the models' performance.
 
 Each model assigns a score to a candidate cell, and a threshold determines whether it is counted as a cell. Using the same threshold for both models does not necessarily give a fair comparison. Instead, I adjusted their thresholds so that both found 99% of the real cells, then measured how often they incorrectly counted non-cell objects as cells.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -68,7 +68,7 @@ Fixing recall pins both models to the same 5016 cells found and 50 missed, so th
 
 ### Closing the gap
 
-This is unfinished work. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Faking the background with a blurred signal fails badly: real background is anti-correlated with signal at a cell, a blurred copy is not. A learned signal-to-background predictor is worth trying next.
+There is more work to be done here. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Faking the background with a blurred signal fails badly: real background is anti-correlated with signal at a cell, a blurred copy is not.
 
 A performance drop from two channels was always expected. However, now, if you only have one channel, `cellfinder` runs. We have an explicit offering for it.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -68,7 +68,7 @@ Fixing recall pins both models to the same 5016 cells found and 50 missed, so th
 
 ### Closing the gap
 
-There is more work to be done here. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Faking the background with a blurred signal fails badly: real background is anti-correlated with signal at a cell, a blurred copy is not.
+There is more work to be done here. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
 
 A performance drop from two channels was always expected. However, now, if you only have one channel, `cellfinder` runs. We have an explicit offering for it.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -25,7 +25,7 @@ However, collecting a second channel doubles the data volume, and for some fluor
 
 ### What changed
 
-The `build_model()` function creates the neural network used to classify candidate cells. The input shape passed to it now reflects the number of channels in the data, allowing the network to accept a signal channel alone. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` shipped expected two channels, so this path also needed retraining.
+The `build_model()` function creates the neural network used to classify candidate cells. The input shape passed to it now reflects the number of channels in the data, allowing the network to accept a signal channel alone. With no background given, `cellfinder` switches to a newly trained single-channel default model automatically, and a channel mismatch raises a clear error. Previously, every pre-trained model `cellfinder` shipped expected two channels.
 
 The same support runs through the napari plugin, so detection, curation and training all work from a signal channel alone. Curation writes only the signal cubes and notes the missing background in the training YAML, so training your own single-channel model needs no extra configuration.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-Hi, I'm [Soumya](https://github.com/aymuos15). I was the [Neuroinformatics Unit](https://github.com/neuroinformatics-unit) GSoC intern for the 2026 summer term, and I worked on broadening the range of inputs [`cellfinder`](https://github.com/brainglobe/cellfinder) accepts, in both channel count and dimensionality.
+Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatics Unit](https://github.com/neuroinformatics-unit) GSoC interns for the 2026 summer term, and I worked on broadening the range of inputs [`cellfinder`](https://github.com/brainglobe/cellfinder) accepts, in both channel count and dimensionality.
 
 **Project**: BrainGlobe: expand `cellfinder` input support to 2.5D and single-channel data <br>
 **Mentors**: [Igor Tatarnikov](https://github.com/IgorTatarnikov), [Alessandro Felder](https://github.com/alessandrofelder), [Adam Tyson](https://github.com/adamltyson)
@@ -27,7 +27,7 @@ It is not free, though. As the [feature request](https://github.com/brainglobe/c
 
 ### What changed
 
-The model builder now takes its channel count from the data instead of assuming two, so `background_array` can be `None` all the way from the public API to the classifier. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` ships expects two channels, so this path also needed retraining.
+The model builder now takes its channel count from the data instead of assuming two, so `background_array` can be `None` all the way from the public API to the classifier. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` shipped expected two channels, so this path also needed retraining.
 
 The same support runs through the napari plugin, so detection, curation and training all work from a signal channel alone. Curation writes only the signal cubes and notes the missing background in the training YAML, so training your own single-channel model needs no extra configuration.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -21,7 +21,7 @@ Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatic
 
 `cellfinder` is BrainGlobe's tool for detecting and classifying cells in whole-brain microscopy volumes. By default, two channels are expected by `cellfinder`. This stems from a finding in the original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)), where the second channel lets the network learn the difference between neuron-based signals, only present in the primary signal channel, and other non-neuronal sources of fluorescence, potentially present in both channels.
 
-It is not free, though. As the [feature request](https://github.com/brainglobe/cellfinder/issues/352) behind this work put it, it is not always practical to double the data collected, and for some fluorophores a channel with only autofluorescence can be hard to obtain at all, which leaves it carrying little information while still costing a full acquisition. Making the background optional was the deliverable I want to talk about here.
+However, collecting a second channel doubles the data volume, and for some fluorophores it is difficult to obtain a channel containing only autofluorescence. These limitations are what originally motivated the [request for single-channel support](https://github.com/brainglobe/cellfinder/issues/352). Making this background channel optional was a major part of my project.
 
 ### What changed
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -66,7 +66,7 @@ The single-channel model made more false-positive errors in every training setup
 
 There is more work to be done here. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
 
-A performance drop from two channels was always expected. However, now, if you only have one channel, `cellfinder` runs. We have an explicit offering for it.
+A performance drop from two channels was always expected. However, now, if you only have one channel, you can know use `cellfinder`.
 
 ---
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -45,7 +45,7 @@ In napari, you leave the background image unselected.
 
 ### How well does it work
 
-I trained a single-channel ResNet-50 on the same serial two-photon dataset used for the existing model and published it on the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), so it downloads on first use like the others.
+I trained a single-channel ResNet-50 on the same serial two-photon dataset used for the existing model and published it on the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), so it downloads automatically on first use like the others.
 
 Headline accuracy figures flatter it, so it is worth being precise about the cost.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -19,9 +19,7 @@ Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatic
 
 ## Project Overview
 
-`cellfinder` detects and classifies labelled cells in whole-brain microscopy volumes. It expected two channels: a signal channel carrying the labelled cells, and a background channel of autofluorescence that the classifier compares against to tell real cells from artefacts.
-
-That second channel earns its place. The original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)) explains that the network can "'learn' the difference between neuron-based signals (only present in the primary signal channel), and other non-neuronal sources of fluorescence (potentially present in both channels)".
+`cellfinder` is BrainGlobe's tool for detecting and classifying cells in whole-brain microscopy volumes. By default, two channels are expected by `cellfinder`. This stems from a finding in the original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)), where the second channel lets the network learn the difference between neuron-based signals, only present in the primary signal channel, and other non-neuronal sources of fluorescence, potentially present in both channels.
 
 It is not free, though. As the [feature request](https://github.com/brainglobe/cellfinder/issues/352) behind this work put it, it is not always practical to double the data collected, and for some fluorophores a channel with only autofluorescence can be hard to obtain at all, which leaves it carrying little information while still costing a full acquisition. Making the background optional was the deliverable I want to talk about here.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -64,7 +64,7 @@ The single-channel model made more false-positive errors in every training setup
 
 ### Closing the gap
 
-I tried a few strategies to improve the default single-channel model's performance. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
+I tried a few strategies to improve the default single-channel model's performance. [Warm-start fine-tuning](https://arxiv.org/abs/1910.08475) recovers roughly 40% of the gap and a [top-hat](https://en.wikipedia.org/wiki/Top-hat_transform) variant around 28%, while [knowledge distillation](https://arxiv.org/abs/1503.02531) does nothing and [hard-negative mining](https://arxiv.org/abs/1604.03540) hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
 
 A performance drop from two channels was always expected. However, now, if you only have one channel, you can know use `cellfinder`.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -45,9 +45,9 @@ In napari, you leave the background image unselected.
 
 ### How well does it work
 
-I trained a single-channel ResNet-50 on the same serial two-photon dataset used for the existing model and published it on the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), so it downloads automatically on first use like the others.
+I used the same ResNet-50 architecture and training dataset as the standard two-channel model, but dropped the background channel during training to create our first single-channel model. I then uploaded it to the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), marking the start of our transition to hosting models there. It downloads automatically on first use, just like the existing models.
 
-Headline accuracy figures flatter it, so it is worth being precise about the cost.
+I then compared our results against the two-channel model to understand the trade-offs it would have.
 
 - Early use on data from a different microscope threw up more false-positive cells than expected.
 - So: cross-validation of single- versus two-channel over three stratified folds, against one frozen test set of 10,756 cubes, 5066 cells and 5690 non-cells.

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -70,7 +70,7 @@ Fixing recall pins both models to the same 5016 cells found and 50 missed, so th
 
 This is unfinished work. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Faking the background with a blurred signal fails badly: real background is anti-correlated with signal at a cell, a blurred copy is not. A learned signal-to-background predictor is worth trying next.
 
-None of this makes single-channel a bad option. If you have no background channel it is now a supported path rather than an impossible one, and knowing what it costs is what lets you decide whether the second acquisition is worth it.
+A performance drop from two channels was always expected. However, now, if you only have one channel, `cellfinder` runs. We have an explicit offering for it.
 
 ---
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -64,7 +64,7 @@ The single-channel model made more false-positive errors in every training setup
 
 ### Closing the gap
 
-There is more work to be done here. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
+I tried a few strategies to improve the default single-channel model's performance. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Substituting a blurred copy of the signal for the missing background also proved unsuccessful, since a real background channel is anti-correlated with the signal at a cell, with a mean background-to-signal intensity ratio of 0.05 at a true cell against 2.00 at a true non-cell, whereas a blurred copy is positively correlated by construction.
 
 A performance drop from two channels was always expected. However, now, if you only have one channel, you can know use `cellfinder`.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -25,7 +25,7 @@ However, collecting a second channel doubles the data volume, and for some fluor
 
 ### What changed
 
-The model builder now takes its channel count from the data instead of assuming two, so `background_array` can be `None` all the way from the public API to the classifier. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` shipped expected two channels, so this path also needed retraining.
+The `build_model()` function creates the neural network used to classify candidate cells. The input shape passed to it now reflects the number of channels in the data, allowing the network to accept a signal channel alone. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` shipped expected two channels, so this path also needed retraining.
 
 The same support runs through the napari plugin, so detection, curation and training all work from a signal channel alone. Curation writes only the signal cubes and notes the missing background in the training YAML, so training your own single-channel model needs no extra configuration.
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatics Unit](https://github.com/neuroinformatics-unit) GSoC interns for the 2026 summer term, and I worked on broadening the range of inputs [`cellfinder`](https://github.com/brainglobe/cellfinder) accepts, in both channel count and dimensionality.
+Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatics Unit](https://github.com/neuroinformatics-unit) [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSoC) interns for the 2026 summer term, and I worked on broadening the range of inputs [`cellfinder`](https://github.com/brainglobe/cellfinder) accepts, in both channel count and dimensionality.
 
 **Project**: BrainGlobe: expand `cellfinder` input support to 2.5D and single-channel data <br>
 **Mentors**: [Igor Tatarnikov](https://github.com/IgorTatarnikov), [Alessandro Felder](https://github.com/alessandrofelder), [Adam Tyson](https://github.com/adamltyson)

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -1,0 +1,94 @@
+:blogpost: true
+:date: August 7, 2026
+:author: Soumya Snigdha Kundu
+:location: London, UK
+:category: Blog
+:language: English
+:image: 0
+
+# GSoC 2026: single-channel support in cellfinder
+
+## Introduction
+
+Hi, I'm [Soumya](https://github.com/aymuos15). I was the [Neuroinformatics Unit](https://github.com/neuroinformatics-unit) GSoC intern for the 2026 summer term, and I worked on broadening the range of inputs [`cellfinder`](https://github.com/brainglobe/cellfinder) accepts, in both channel count and dimensionality.
+
+**Project**: BrainGlobe: expand `cellfinder` input support to 2.5D and single-channel data <br>
+**Mentors**: [Igor Tatarnikov](https://github.com/IgorTatarnikov), [Alessandro Felder](https://github.com/alessandrofelder), [Adam Tyson](https://github.com/adamltyson)
+
+---
+
+## Project Overview
+
+`cellfinder` detects and classifies labelled cells in whole-brain microscopy volumes. It expected two channels: a signal channel carrying the labelled cells, and a background channel of autofluorescence that the classifier compares against to tell real cells from artefacts.
+
+That second channel earns its place. The original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)) describes it as "a secondary 'autofluorescence' channel that does not contain target signals but provides anatomical outlines", acquired so that the network can "'learn' the difference between neuron-based signals (only present in the primary signal channel), and other non-neuronal sources of fluorescence (potentially present in both channels)".
+
+It is not free, though. As the [feature request](https://github.com/brainglobe/cellfinder/issues/352) behind this work put it, it is not always practical to double the data collected, and for some fluorophores a channel with only autofluorescence can be hard to obtain at all, which leaves it carrying little information while still costing a full acquisition. Making the background optional was the deliverable I want to talk about here.
+
+### What changed
+
+The model builder now takes its channel count from the data instead of assuming two, so `background_array` can be `None` all the way from the public API to the classifier. With no background given, `cellfinder` switches to a single-channel model automatically, and a channel mismatch raises a clear error. Every pre-trained model `cellfinder` ships expects two channels, so this path also needed retraining.
+
+The same support runs through the napari plugin, so detection, curation and training all work from a signal channel alone. Curation writes only the signal cubes and notes the missing background in the training YAML, so training your own single-channel model needs no extra configuration.
+
+From Python, it is one argument:
+
+```python
+from cellfinder.core.main import main
+
+cells = main(
+    signal_array=signal,
+    background_array=None,
+    voxel_sizes=(5, 2, 2),
+)
+```
+
+In napari, you leave the background image unselected.
+
+### How well does it work
+
+I trained a single-channel ResNet-50 on the same serial two-photon dataset used for the existing model and published it on the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), so it downloads on first use like the others.
+
+Headline accuracy figures flatter it, so it is worth being precise about the cost.
+
+- Early use on data from a different microscope threw up more false-positive cells than expected.
+- So: cross-validation of single- versus two-channel over three stratified folds, against one frozen test set of 10,756 cubes, 5066 cells and 5690 non-cells.
+- Plus a sweep skewing the class balance of the training data, to separate "not enough data" from "weaker input".
+- At a fixed threshold the two models look nearly identical, but that is an artefact: they sit at different points on their curves.
+- The comparison that shows the difference is at a matched operating point, here a recall of 0.99.
+
+| Training set | Threshold 1-ch | Threshold 2-ch | FP rate 1-ch (%) | FP rate 2-ch (%) |
+|---|---|---|---|---|
+| Balanced (47% cell) | 0.406 ± 0.018 | 0.495 ± 0.069 | 4.46 ± 0.23 | 3.58 ± 0.04 |
+| Skew 60% cell | 0.270 ± 0.046 | 0.599 ± 0.075 | 5.09 ± 0.32 | 3.83 ± 0.06 |
+| Skew 70% cell | 0.298 ± 0.082 | 0.663 ± 0.053 | 5.65 ± 0.39 | 4.18 ± 0.09 |
+| Skew 80% cell | 0.222 ± 0.044 | 0.760 ± 0.093 | 5.08 ± 0.21 | 4.05 ± 0.16 |
+
+Fixing recall pins both models to the same 5016 cells found and 50 missed, so the whole difference lands in false positives: 254 against 204 on balanced data, 321 against 238 at 70% skew. Those 50 to 80 extra spurious cells never show up in an accuracy score. The thresholds diverge too, and more so with skew, so tune the threshold per model rather than leaving it at the default.
+
+### Closing the gap
+
+This is unfinished work. Warm-start fine-tuning recovers roughly 40% of the gap and a top-hat variant around 28%, while distillation does nothing and hard-negative mining hurts. Faking the background with a blurred signal fails badly: real background is anti-correlated with signal at a cell, a blurred copy is not. A learned signal-to-background predictor is worth trying next.
+
+None of this makes single-channel a bad option. If you have no background channel it is now a supported path rather than an impossible one, and knowing what it costs is what lets you decide whether the second acquisition is worth it.
+
+---
+
+## Reflections
+
+A big reason I applied for this project is how closely it sits to my PhD work, and it was genuinely interesting to take the techniques I use there and apply them over here, on a different problem and a different kind of data.
+
+Working with a larger group was the other half of it. Seeing how research gets translated into software people can rely on, through review, tests and carefully chosen defaults, was the most useful thing I took from the summer.
+
+Single-channel support was one of three deliverables, and I am carrying on with the other two: extending the classifier to two-dimensional and 2.5D input so that brain slices are as well supported as whole volumes, and standardising the axis conventions underneath that make any change to dimensionality error-prone. Both are already under way, and I am looking forward to seeing them land.
+
+---
+
+## Repositories
+
+- [`cellfinder`](https://github.com/brainglobe/cellfinder)
+- [`brainglobe.github.io`](https://github.com/brainglobe/brainglobe.github.io/)
+
+---
+
+*Thank you to my mentors and the whole team at NIU and BrainGlobe for their patience, their reviews, and their guidance throughout the summer!*

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -47,22 +47,20 @@ In napari, you leave the background image unselected.
 
 I used the same ResNet-50 architecture and training dataset as the standard two-channel model, but dropped the background channel during training to create our first single-channel model. I then uploaded it to the [Hugging Face Hub](https://huggingface.co/brainglobe/cellfinder_single_channel_default), marking the start of our transition to hosting models there. It downloads automatically on first use, just like the existing models.
 
-I then compared our results against the two-channel model to understand the trade-offs it would have.
+I then compared our results against the two-channel model to understand the trade-offs it would have. Early tests on data from a different microscope produced more false positives: objects incorrectly identified as cells. I tested both models on the same set of 10,756 image cubes, containing 5,066 cells and 5,690 non-cell objects, and varied the proportion of cells in the training data to see how it affected their performance.
 
-- Early use on data from a different microscope threw up more false-positive cells than expected.
-- So: cross-validation of single- versus two-channel over three stratified folds, against one frozen test set of 10,756 cubes, 5066 cells and 5690 non-cells.
-- Plus a sweep skewing the class balance of the training data, to separate "not enough data" from "weaker input".
-- At a fixed threshold the two models look nearly identical, but that is an artefact: they sit at different points on their curves.
-- The comparison that shows the difference is at a matched operating point, here a recall of 0.99.
+Each model assigns a score to a candidate cell, and a threshold determines whether it is counted as a cell. Using the same threshold for both models does not necessarily give a fair comparison. Instead, I adjusted their thresholds so that both found 99% of the real cells, then measured how often they incorrectly counted non-cell objects as cells.
 
-| Training set | Threshold 1-ch | Threshold 2-ch | FP rate 1-ch (%) | FP rate 2-ch (%) |
-|---|---|---|---|---|
-| Balanced (47% cell) | 0.406 ± 0.018 | 0.495 ± 0.069 | 4.46 ± 0.23 | 3.58 ± 0.04 |
-| Skew 60% cell | 0.270 ± 0.046 | 0.599 ± 0.075 | 5.09 ± 0.32 | 3.83 ± 0.06 |
-| Skew 70% cell | 0.298 ± 0.082 | 0.663 ± 0.053 | 5.65 ± 0.39 | 4.18 ± 0.09 |
-| Skew 80% cell | 0.222 ± 0.044 | 0.760 ± 0.093 | 5.08 ± 0.21 | 4.05 ± 0.16 |
+The single-channel model made more false-positive errors in every training setup. With the original training balance, it incorrectly classified around 4.5% of non-cell objects, compared with 3.6% for the two-channel model. Increasing the proportion of cells in the training data did not close this gap.
 
-Fixing recall pins both models to the same 5016 cells found and 50 missed, so the whole difference lands in false positives: 254 against 204 on balanced data, 321 against 238 at 70% skew. Those 50 to 80 extra spurious cells never show up in an accuracy score. The thresholds diverge too, and more so with skew, so tune the threshold per model rather than leaving it at the default.
+| Cells in the training data | Non-cell objects counted as cells: single-channel | Two-channel |
+|---|---:|---:|
+| 47% (original balance) | 4.46% | 3.58% |
+| 60% | 5.09% | 3.83% |
+| 70% | 5.65% | 4.18% |
+| 80% | 5.08% | 4.05% |
+
+*Values are averages across three training runs.*
 
 ### Closing the gap
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -76,7 +76,9 @@ A big reason I applied for this project is how closely it sits to my PhD work, a
 
 Working with a larger group was the other half of it. Seeing how research gets translated into software people can rely on, through review, tests and carefully chosen defaults, was the most useful thing I took from the summer.
 
-Single-channel support was one of three deliverables, and I am carrying on with the other two: extending the classifier to two-dimensional and 2.5D input so that brain slices are as well supported as whole volumes, and standardising the axis conventions underneath that make any change to dimensionality error-prone. Both are already under way, and I am looking forward to seeing them land.
+I also really enjoyed the opportunity to present this work at the [NIU Open Software Summer School](https://neuroinformatics.dev/slides-osss-intro/#/friday-approximate) and hear some very interesting feedback from the participants.
+
+Single-channel support was one of three deliverables, and I am carrying on with the other two: extending the classifier to two-dimensional and 2.5D input so that brain slices are as well supported as whole volumes, and standardising the axis conventions underneath that make any change to dimensionality error-prone. Both are already under way, incorporating the additional feedback gathered at the summer school, and I am looking forward to seeing them land.
 
 ---
 

--- a/docs/source/blog/gsoc_2026_cellfinder.md
+++ b/docs/source/blog/gsoc_2026_cellfinder.md
@@ -21,7 +21,7 @@ Hi, I'm [Soumya](https://github.com/aymuos15). I was one of the [Neuroinformatic
 
 `cellfinder` detects and classifies labelled cells in whole-brain microscopy volumes. It expected two channels: a signal channel carrying the labelled cells, and a background channel of autofluorescence that the classifier compares against to tell real cells from artefacts.
 
-That second channel earns its place. The original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)) describes it as "a secondary 'autofluorescence' channel that does not contain target signals but provides anatomical outlines", acquired so that the network can "'learn' the difference between neuron-based signals (only present in the primary signal channel), and other non-neuronal sources of fluorescence (potentially present in both channels)".
+That second channel earns its place. The original `cellfinder` paper ([Tyson et al., 2021](https://doi.org/10.1371/journal.pcbi.1009074)) explains that the network can "'learn' the difference between neuron-based signals (only present in the primary signal channel), and other non-neuronal sources of fluorescence (potentially present in both channels)".
 
 It is not free, though. As the [feature request](https://github.com/brainglobe/cellfinder/issues/352) behind this work put it, it is not always practical to double the data collected, and for some fluorophores a channel with only autofluorescence can be hard to obtain at all, which leaves it carrying little information while still costing a full acquisition. Making the background optional was the deliverable I want to talk about here.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,6 +83,7 @@ linkcheck_ignore = [
     "https://www.incf.org/recommendations-gsoc-contributors",
     "https://www.incf.org/sites/default/files/files/INCF_GSoC_2022_Application_template.pdf",
     "https://neuroinformatics.dev/slides-templates-atlases/#/on-templates-and-atlases",
+    "https://neuroinformatics.dev/slides-osss-intro/#/friday-approximate",
     "https://errantscience.com/",
     "https://in2scienceuk.org/our-programmes/in2research/",
     "https://www.biorxiv.org/content/10.1101/2025.03.30.645770v1",
@@ -227,6 +228,7 @@ fontawesome_included = True
 
 redirects = {
     'open-software-week/index.html': '/open-software-summer-school/index.html',
+    'gsoc-2026-cellfinder.html': '/blog/gsoc_2026_cellfinder.html',
 }
 
 # Hide the "Show Source" button


### PR DESCRIPTION
Adds a blog post covering my GSoC 2026 internship work on `cellfinder`.