### PR TITLE
Add course materials links to 2026 OSSS track pages

### DIFF
--- a/docs/source/open-software-summer-school/2026/animals-in-motion.md
+++ b/docs/source/open-software-summer-school/2026/animals-in-motion.md
@@ -53,12 +53,14 @@ The final two days are dedicated to collaboration. We will join forces with part
 * **Presentation:** teams will have the opportunity to share their progress and outcomes on the final afternoon.
 
 
-::: {admonition} Course handbook
+::: {admonition} Course materials
 :class: note
 
-All course materials will be made available as part of the online handbook at <https://animals-in-motion.neuroinformatics.dev> and remain accessible afterwards.
+All course materials are published in the online handbook at <https://animals-in-motion.neuroinformatics.dev>
+and remain accessible after the event.
 
-Feel free to look through the handbook to get a sense of its contents, but keep in mind that updates will be made before the 2026 event.
+The source code for the course materials is publicly hosted at
+<https://github.com/neuroinformatics-unit/course-animals-in-motion>.
 
 :::
 

--- a/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
+++ b/docs/source/open-software-summer-school/2026/extracellular-electrophysiology.md
@@ -79,6 +79,16 @@ The final two days are dedicated to collaboration. We will join forces with part
     * *Prototype an idea:* experiment with a new analysis or method.
 * **Presentation:** teams will have the opportunity to share their progress and outcomes on the final afternoon.
 
+::: {admonition} Course materials
+:class: note
+
+The course notebooks and tutorials are hosted on GitHub at
+<https://github.com/neuroinformatics-unit/course-spikeinterface-2026>.
+
+The [SpikeInterface documentation](https://spikeinterface.readthedocs.io) serves as the primary reference throughout the course and remains freely accessible.
+
+:::
+
 ## Confirmed Instructors
 
 * [Joseph Ziminski](https://github.com/JoeZiminski)

--- a/docs/source/open-software-summer-school/2026/large-data.md
+++ b/docs/source/open-software-summer-school/2026/large-data.md
@@ -39,6 +39,14 @@ The final two days are dedicated to collaboration. We will join forces with part
     * *Prototype an idea:* experiment with a new analysis or method.
 * **Presentation:** teams will have the opportunity to share their progress and outcomes on the final afternoon.
 
+::: {admonition} Course materials
+:class: note
+
+The slides and source materials for this course are publicly available at
+<https://github.com/neuroinformatics-unit/slides-large-array-data-osss-2026>.
+
+:::
+
 ## Confirmed Instructors
 - [Alessandro Felder](https://github.com/alessandrofelder)
 - [Igor Tatarnikov](https://github.com/IgorTatarnikov)


### PR DESCRIPTION
Addresses #322

PR #323 added a materials link for the BrainGlobe track. This PR
covers the three remaining 2026 tracks that still had no clear link
to their workshop materials:

- **Large Array Data**: Add "Course materials" admonition linking to
  the slides repository (`slides-large-array-data-osss-2026`).
- **Extracellular Electrophysiology**: Add "Course materials"
  admonition linking to the course notebooks and SpikeInterface docs.
- **Animals in Motion**: Update the existing admonition to remove the
  pre-event caveat (the 2026 event has taken place) and add a link
  to the source code repository.

The admonition style matches the existing "Course slides" note on the
BrainGlobe 2026 page introduced in #323.
