### PR TITLE
Add NIU tools sidebar dropdown switcher

### DIFF
--- a/docs/dev/sidebar-switcher-reference.md
+++ b/docs/dev/sidebar-switcher-reference.md
@@ -1,0 +1,80 @@
+# Implementation Summary
+
+## 1. What was built
+A sidebar dropdown ("NIU Tools") was added to the site navigation that links out to the Neuroinformatics Unit's other project sites. This is visually similar to the project switcher found on panel.holoviz.org, but it was implemented as our own lightweight, vendored version rather than directly importing and depending on HoloViz's `nbsite` package.
+
+## 2. Why we didn't just import nbsite
+We tested importing `nbsite.shared_conf` directly in a local build. We found that `nbsite` overrides Sphinx's `html_theme`, forces HoloViz's CSS, heavily modifies the `html_theme_options`, and hardcodes source code links to resolve to `github.com/holoviz`. More importantly, because Python executes top-down, NIU's own `conf.py` naturally overwrites the variables `nbsite` sets up, erasing the sidebar switcher entirely unless heavily hacked. Vendoring the template proved to be much safer and avoids breaking the existing site.
+
+## 3. How it's implemented
+The implementation has three core components:
+- **The Template:** `docs/source/_templates/niu-sidebar-dropdown.html`. This Jinja template renders the dropdown HTML. It iterates over a configuration dictionary to build the project list using the exact same Jinja pattern as the original HoloViz template.
+- **The Context Hook:** In `docs/source/conf.py`, a setup hook (`add_niu_sidebar_dropdown_context`) is registered via `app.connect("html-page-context", ...)`. This hook injects the project list into the Jinja template context on every build.
+- **The Configuration Dictionary:** The actual project list lives in `docs/source/conf.py` under the variable `niu_sidebar_dropdown`. It looks like this:
+  ```python
+  niu_sidebar_dropdown = {
+      'dropdown_value': { 'href': 'https://neuroinformatics.dev/', 'text': 'NIU Tools' },
+      'projects': {
+          'brainglobe': {
+              'text': 'BrainGlobe',          # The text shown in the dropdown
+              'url': 'https://brainglobe.info/', # The destination URL
+              'title': 'BrainGlobe...'       # Tooltip text shown on hover
+          },
+          # ...
+      },
+      'others': {}
+  }
+  ```
+- **The Sidebar Registration:** In `docs/source/conf.py`, the template is explicitly prepended to the `html_sidebars` dictionary for `"**"`, `"blog/index"`, and `"blog/**"`. This ensures the dropdown merges with NIU's existing sidebar structure rather than replacing it.
+
+## 4. How to update the project list
+To add, remove, or edit a project link in the sidebar:
+1. Open `docs/source/conf.py`.
+2. Locate the `niu_sidebar_dropdown` dictionary.
+3. Under the `projects` key, add or edit a dictionary block. Provide a simple key name (e.g., `'datashuttle'`), and specify the `text` (display name), `url` (link destination), and `title` (hover tooltip).
+4. No HTML or template changes are required! Sphinx will automatically read the updated dictionary on the next build.
+
+## 5. What's still placeholder / needs input
+The current `niu_sidebar_dropdown` dictionary in `conf.py` contains **placeholder entries** (BrainGlobe, DataShuttle, and Movement). The exact, finalized list of NIU projects and URLs needs to be provided by the maintainer and updated in `conf.py` before this pull request can be merged.
+
+## 6. How to test it locally
+To test the implementation on your own machine:
+1. Activate your virtual environment and install dependencies: `pip install -r docs/requirements.txt`.
+2. Build the Sphinx docs: `make html` (on Mac/Linux) or `.\make.bat html` (on Windows) inside the `docs` directory.
+3. Start a local server: `python -m http.server 8000 -d docs/build/html`.
+4. Open your browser to `http://localhost:8000`. Verify that the "NIU Tools" dropdown appears in the left sidebar, the links work, hover tooltips appear, and the existing site theme remains unaffected.
+
+---
+
+
+```html
+{% if hv_sidebar_dropdown %}
+<div class="hv-sb-dd">
+  <div class="btn-group">
+    {% if 'href' in hv_sidebar_dropdown['dropdown_value'] %}
+    <a href="{{ hv_sidebar_dropdown['dropdown_value']['href'] }}" class="btn hv-sb-dd-value" target="_blank">{{ hv_sidebar_dropdown['dropdown_value']['text'] }}<i class="fa fa-external-link hv-icon" aria-hidden="true"></i></a>
+    {% else %}
+    <span class="btn hv-sb-dd-value">{{ hv_sidebar_dropdown['dropdown_value']['text'] }}</span>
+    {% endif %}
+    <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+      <span class="visually-hidden"></span>
+    </button>
+    <ul class="dropdown-menu">
+      {% for project_name, project_opts in hv_sidebar_dropdown['libraries'].items() %}
+      {% if project_name | lower not in project | lower %}
+        <li><a class="dropdown-item" href="{{ project_opts['url'] }}" target="_blank" title="{{ project_opts['title'] }}">{{ project_opts['text'] }}<i class="fa fa-external-link hv-icon" aria-hidden="true"></i></a></li>
+      {% endif %}
+      {% endfor %}
+      {% if hv_sidebar_dropdown['others'] %}
+      <li><hr class="dropdown-divider"></li>
+      {% for project_name, project_opts in hv_sidebar_dropdown['others'].items() %}
+      {% if project_name | lower not in project | lower %}
+      <li><a class="dropdown-item" href="{{ project_opts['url'] }}" target="_blank" title="{{ project_opts['title'] }}">{{ project_opts['text'] }}<i class="fa fa-external-link hv-icon" aria-hidden="true"></i></a></li>
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+    </ul>
+  </div>
+</div>
+{% endif %}
+```

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -72,3 +72,42 @@ html[data-theme=dark] .bd-main img {
   flex-wrap: wrap;
   justify-content: space-between;
 }
+
+/* Sidebar Switcher Styling */
+.niu-sb-dd {
+    margin: 10px 15px;
+}
+.niu-sb-dd .btn-group {
+    width: 100%;
+}
+.niu-sb-dd-value {
+    flex-grow: 1;
+    text-align: left;
+    font-weight: 600;
+    background-color: var(--pst-color-surface);
+    border: 1px solid var(--pst-color-border);
+    color: var(--pst-color-text-base);
+}
+.niu-sb-dd .dropdown-toggle {
+    background-color: var(--pst-color-surface);
+    border: 1px solid var(--pst-color-border);
+    color: var(--pst-color-text-base);
+}
+.niu-sb-dd .dropdown-menu {
+    width: 100%;
+    background-color: var(--pst-color-surface);
+}
+.niu-sb-dd .dropdown-item {
+    color: var(--pst-color-text-base);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.niu-sb-dd .dropdown-item:hover {
+    background-color: var(--pst-color-surface-hover);
+}
+.niu-icon {
+    font-size: 0.8em;
+    margin-left: 8px;
+    opacity: 0.7;
+}

--- a/docs/source/_templates/niu-sidebar-dropdown.html
+++ b/docs/source/_templates/niu-sidebar-dropdown.html
@@ -1,0 +1,29 @@
+{% if niu_sidebar_dropdown and niu_sidebar_dropdown.get('dropdown_value') and (niu_sidebar_dropdown.get('projects') or niu_sidebar_dropdown.get('others')) %}
+<div class="niu-sb-dd">
+  <div class="btn-group">
+    {% if 'href' in niu_sidebar_dropdown['dropdown_value'] %}
+    <a href="{{ niu_sidebar_dropdown['dropdown_value']['href'] }}" class="btn niu-sb-dd-value" target="_blank">{{ niu_sidebar_dropdown['dropdown_value']['text'] }}<i class="fa fa-external-link niu-icon" aria-hidden="true"></i></a>
+    {% else %}
+    <span class="btn niu-sb-dd-value">{{ niu_sidebar_dropdown['dropdown_value']['text'] }}</span>
+    {% endif %}
+    <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+      <span class="visually-hidden"></span>
+    </button>
+    <ul class="dropdown-menu">
+      {% for project_name, project_opts in niu_sidebar_dropdown['projects'].items() %}
+      {% if project_name | lower not in project | lower %}
+        <li><a class="dropdown-item" href="{{ project_opts['url'] }}" target="_blank" title="{{ project_opts['title'] }}">{{ project_opts['text'] }}<i class="fa fa-external-link niu-icon" aria-hidden="true"></i></a></li>
+      {% endif %}
+      {% endfor %}
+      {% if niu_sidebar_dropdown['others'] %}
+      <li><hr class="dropdown-divider"></li>
+      {% for project_name, project_opts in niu_sidebar_dropdown['others'].items() %}
+      {% if project_name | lower not in project | lower %}
+      <li><a class="dropdown-item" href="{{ project_opts['url'] }}" target="_blank" title="{{ project_opts['title'] }}">{{ project_opts['text'] }}<i class="fa fa-external-link niu-icon" aria-hidden="true"></i></a></li>
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+    </ul>
+  </div>
+</div>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,15 +219,52 @@ html_theme_options = {
 # post pages, see https://ablog.readthedocs.io/en/latest/manual/templates-themes.html
 # Note: this replaces the default site nav sidebar on blog pages only.
 html_sidebars = {
+    "**": [
+        "niu-sidebar-dropdown.html",
+        "sidebar-nav-bs",
+    ],
     "blog/index": [
+        "niu-sidebar-dropdown.html",
         "ablog/authors.html",
         "ablog/archives.html",
     ],
     "blog/**": [
+        "niu-sidebar-dropdown.html",
         "ablog/postcard.html",
         "ablog/recentposts.html",
     ],
 }
+
+niu_sidebar_dropdown = {
+    'dropdown_value': {
+        'href': 'https://neuroinformatics.dev/',
+        'text': 'NIU Tools',
+    },
+    'projects': {
+        'brainglobe': {
+            'text': 'BrainGlobe',
+            'url': 'https://brainglobe.info/',
+            'title': 'BrainGlobe: Interoperable tools for computational neuroanatomy.',
+        },
+        'datashuttle': {
+            'text': 'DataShuttle',
+            'url': 'https://datashuttle.neuroinformatics.dev/',
+            'title': 'DataShuttle: Data transfer and validation.',
+        },
+        'movement': {
+            'text': 'Movement',
+            'url': 'https://movement.neuroinformatics.dev/',
+            'title': 'Movement: Tools for analysing behavioural videos.',
+        },
+    },
+    'others': {}
+}
+
+def add_niu_sidebar_dropdown_context(app, pagename, templatename, context, doctree, *args) -> None:
+    context['niu_sidebar_dropdown'] = niu_sidebar_dropdown
+
+def setup(app):
+    app.connect("html-page-context", add_niu_sidebar_dropdown_context)
 
 # The PyData theme bundles FontAwesome, so let ABlog render its postcard icons
 # (calendar, user, ...) instead of plain-text "Author:"/"Location:" labels.


### PR DESCRIPTION

Closes : #278 
<img width="1891" height="857" alt="Screenshot 2026-09-12 230601" src="https://github.com/user-attachments/assets/da8dc235-118e-46b0-941e-2a194272a33d" />

## What this does

Adds a "NIU Tools" dropdown to the site's left sidebar, linking out to other NIU project
sites (similar to the project switcher on panel.holoviz.org). Clicking the label expands a
list of external project links, each with a hover tooltip.

Full writeup, including why HoloViz's `nbsite` package wasn't used directly, is in
`docs/dev/sidebar-switcher-reference.md`.

## How it's implemented

- `docs/source/_templates/niu-sidebar-dropdown.html` — vendored Jinja template rendering the
  dropdown
- `docs/source/conf.py` — adds the `niu_sidebar_dropdown` config dict (the actual project
  list), a context hook that injects it into the page template, and registers the template
  in `html_sidebars` alongside the existing sidebar nav (not replacing it)
- `docs/source/_static/css/custom.css` — styling for the dropdown, using the theme's existing
  PyData color variables so it matches light/dark mode automatically

## How has this PR been tested?

Built the docs locally (`make html`) and verified in browser:
- Dropdown renders on the homepage, on nested `/howto/` pages, and on blog pages
- Existing sidebar nav is unaffected — dropdown appears alongside it, not replacing it
- Links open correctly, tooltips show on hover
- Light and dark theme both render correctly
- No new build warnings/errors
- Confirmed `nbsite` is not a dependency, and GitHub source links still point to this repo

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

Added `docs/dev/sidebar-switcher-reference.md`, documenting the implementation and how to
update the project list going forward.

## Still needed before merge

The `niu_sidebar_dropdown` project list currently contains **placeholder entries**
(BrainGlobe, DataShuttle, Movement) used for testing. @adamltyson — could you confirm the
actual, final list of projects/tools you'd like linked here? Updating it afterward is a
one-line dict edit in `conf.py`, no template changes needed.

## Checklist

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality *(no automated test suite exists
      for sidebar rendering in this repo — happy to add one if there's a preferred pattern)*
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/) *(confirm before
      merging — run `pre-commit run --all-files` if not already done)*